### PR TITLE
complements the change in the correspondences.pyx

### DIFF
--- a/pyptv/ptv.py
+++ b/pyptv/ptv.py
@@ -214,15 +214,19 @@ def py_sequence_loop(exp):
         pos, rcm = point_positions(
             flat.transpose(1,0,2), cpar, cals)
 
-        if len(cals) == 1: # single camera case
-            sorted_corresp = np.tile(sorted_corresp,(4,1))
-            sorted_corresp[1:,:] = -1
+        # if len(cals) == 1: # single camera case
+        #     sorted_corresp = np.tile(sorted_corresp,(4,1))
+        #     sorted_corresp[1:,:] = -1
+
+        if len(cals) < 4:
+            print_corresp = -1*np.ones((4,sorted_corresp.shape[1]))
+            print_corresp[:len(cals),:] = sorted_corresp
 
         # Save rt_is
         rt_is = open(default_naming['corres']+'.'+str(frame), 'w')
         rt_is.write(str(pos.shape[0]) + '\n')
         for pix, pt in enumerate(pos):
-            pt_args = (pix + 1,) + tuple(pt) + tuple(sorted_corresp[:,pix])
+            pt_args = (pix + 1,) + tuple(pt) + tuple(print_corresp[:,pix])
             rt_is.write("%4d %9.3f %9.3f %9.3f %4d %4d %4d %4d\n" % pt_args)
         rt_is.close()
     # end of a sequence loop    


### PR DESCRIPTION
fixes the rt_is.write for less than 4 camera case (including 1 camera… case, not tested)

before everything, you need to update the liboptv with the py_bind/optv/correspondences.pyx - see the solution of the bug reported in #9 and #8  (i copied the same error report) in https://github.com/OpenPTV/openptv/pull/161

